### PR TITLE
Fix URLSessionDelegate methods for Swift 4

### DIFF
--- a/MZDownloadManager/Classes/MZDownloadManager.swift
+++ b/MZDownloadManager/Classes/MZDownloadManager.swift
@@ -166,9 +166,9 @@ extension MZDownloadManager {
     }
 }
 
-extension MZDownloadManager: URLSessionDelegate {
-    
-    func URLSession(_ session: Foundation.URLSession, downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) {
+extension MZDownloadManager: URLSessionDownloadDelegate {
+  
+    public func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) {
         for (index, downloadModel) in self.downloadingArray.enumerated() {
             if downloadTask.isEqual(downloadModel.task) {
                 DispatchQueue.main.async(execute: { () -> Void in
@@ -214,7 +214,7 @@ extension MZDownloadManager: URLSessionDelegate {
         }
     }
     
-    func URLSession(_ session: Foundation.URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingToURL location: URL) {
+    public func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
         for (index, downloadModel) in downloadingArray.enumerated() {
             if downloadTask.isEqual(downloadModel.task) {
                 let fileName = downloadModel.fileName as NSString
@@ -255,11 +255,12 @@ extension MZDownloadManager: URLSessionDelegate {
         }
     }
     
-    func URLSession(_ session: Foundation.URLSession, task: URLSessionTask, didCompleteWithError error: NSError?) {
+    public func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         debugPrint("task id: \(task.taskIdentifier)")
         /***** Any interrupted tasks due to any reason will be populated in failed state after init *****/
         
         DispatchQueue.main.async {
+            let error = error as NSError?
             if (error?.userInfo[NSURLErrorBackgroundTaskCancelledReasonKey] as? NSNumber)?.intValue == NSURLErrorCancelledReasonUserForceQuitApplication || (error?.userInfo[NSURLErrorBackgroundTaskCancelledReasonKey] as? NSNumber)?.intValue == NSURLErrorCancelledReasonBackgroundUpdatesDisabled {
                 
                 let downloadTask = task as! URLSessionDownloadTask


### PR DESCRIPTION
URLSessionDelegate Methods have been renamed with Swift 4, for that reason the current implementations were not called in Swift 4.

Fixes #61 & #62 