### PR TITLE
Accept custom URLSessionConfiguration when initializing MZDownloadManager

### DIFF
--- a/MZDownloadManager/Classes/MZDownloadManager.swift
+++ b/MZDownloadManager/Classes/MZDownloadManager.swift
@@ -177,7 +177,7 @@ extension MZDownloadManager: URLSessionDownloadDelegate {
                     let totalBytesCount = Double(downloadTask.countOfBytesExpectedToReceive)
                     let progress = Float(receivedBytesCount / totalBytesCount)
                     
-                    let taskStartedDate = downloadModel.startTime!
+                    let taskStartedDate = downloadModel.startTime ?? Date()
                     let timeInterval = taskStartedDate.timeIntervalSinceNow
                     let downloadTime = TimeInterval(-1 * timeInterval)
                     
@@ -205,7 +205,9 @@ extension MZDownloadManager: URLSessionDownloadDelegate {
                     downloadModel.speed = (speedSize, speedUnit as String)
                     downloadModel.progress = progress
                     
-                    self.downloadingArray[index] = downloadModel
+                    if self.downloadingArray.contains(downloadModel), let objectIndex = self.downloadingArray.index(of: downloadModel) {
+                        self.downloadingArray[objectIndex] = downloadModel
+                    }
                     
                     self.delegate?.downloadRequestDidUpdateProgress(downloadModel, index: index)
                 })

--- a/MZDownloadManager/Classes/MZDownloadManager.swift
+++ b/MZDownloadManager/Classes/MZDownloadManager.swift
@@ -76,26 +76,21 @@ open class MZDownloadManager: NSObject {
     
     open var downloadingArray: [MZDownloadModel] = []
     
-    public convenience init(session sessionIdentifer: String, delegate: MZDownloadManagerDelegate) {
+    public convenience init(session sessionIdentifer: String, delegate: MZDownloadManagerDelegate, sessionConfiguration: URLSessionConfiguration? = nil, completion: (() -> Void)? = nil) {
         self.init()
-        
         self.delegate = delegate
-        self.sessionManager = backgroundSession(identifier: sessionIdentifer)
+        self.sessionManager = backgroundSession(identifier: sessionIdentifer, configuration: sessionConfiguration)
         self.populateOtherDownloadTasks()
-    }
-    
-    public convenience init(session sessionIdentifer: String, delegate: MZDownloadManagerDelegate, completion: (() -> Void)?) {
-        self.init(session: sessionIdentifer, delegate: delegate)
         self.backgroundSessionCompletionHandler = completion
     }
     
-    fileprivate func backgroundSession(identifier: String) -> URLSession {
-        let sessionConfiguration = URLSessionConfiguration.background(withIdentifier: identifier)
-      
-        sessionConfiguration.timeoutIntervalForRequest = 60.0
-        sessionConfiguration.timeoutIntervalForResource = 60.0 * 60.0 * 24
-        sessionConfiguration.httpMaximumConnectionsPerHost = 3
-
+    public class func defaultSessionConfiguration(identifier: String) -> URLSessionConfiguration {
+        return URLSessionConfiguration.background(withIdentifier: identifier)
+    }
+    
+    fileprivate func backgroundSession(identifier: String, configuration: URLSessionConfiguration? = nil) -> URLSession {
+        var sessionConfiguration = configuration ?? MZDownloadManager.defaultSessionConfiguration(identifier: identifier)
+        assert(identifier == sessionConfiguration.identifier, "Configuration identifiers do not match")
         let session = Foundation.URLSession(configuration: sessionConfiguration, delegate: self, delegateQueue: nil)
         return session
     }

--- a/MZDownloadManager/Classes/MZDownloadManager.swift
+++ b/MZDownloadManager/Classes/MZDownloadManager.swift
@@ -91,6 +91,11 @@ open class MZDownloadManager: NSObject {
     
     fileprivate func backgroundSession(identifier: String) -> URLSession {
         let sessionConfiguration = URLSessionConfiguration.background(withIdentifier: identifier)
+      
+        sessionConfiguration.timeoutIntervalForRequest = 60.0
+        sessionConfiguration.timeoutIntervalForResource = 60.0 * 60.0 * 24
+        sessionConfiguration.httpMaximumConnectionsPerHost = 3
+
         let session = Foundation.URLSession(configuration: sessionConfiguration, delegate: self, delegateQueue: nil)
         return session
     }


### PR DESCRIPTION
This PR adds an optional `URLSessionConfiguration` argument to the initializer for `MZDownloadManager` so that clients can set their own custom configuration properties.

This also includes some minor fixes for crashes that @alecgorge found.